### PR TITLE
Fix memory leak usage

### DIFF
--- a/Plugin/MonologPlugin.php
+++ b/Plugin/MonologPlugin.php
@@ -14,17 +14,17 @@ use Opengento\Logger\Handler\MagentoHandlerInterface;
 
 class MonologPlugin
 {
-    public function aroundSetHandlers(Monolog $subject, callable $proceed, array $handlers): void
+    public function beforeSetHandlers(Monolog $subject, array $handlers): array
     {
         $magentoHandlers = [];
-        foreach ($handlers as $handler) {
+        foreach ($handlers as $key => $handler) {
             if ($handler instanceof MagentoHandlerInterface && $handler->isEnabled()) {
-                $magentoHandlers[] = $handler->getInstance();
+                $magentoHandlers[$key] = $handler->getInstance();
             } elseif ($handler instanceof HandlerInterface) {
-                $magentoHandlers[] = $handler;
+                $magentoHandlers[$key] = $handler;
             }
         }
 
-        $proceed($magentoHandlers);
+        return [$magentoHandlers];
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -5,19 +5,18 @@
  * See LICENSE bundled with this library for license details.
  */
 -->
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
 
-    <virtualType name="gelfTransport" type="Opengento\Logger\Transport\UdpTransportWrapper">
+    <virtualType name="GelfTransport" type="Opengento\Logger\Transport\UdpTransportWrapper">
         <arguments>
             <argument name="hostPath" xsi:type="string">loggin/gelf/transport_host</argument>
             <argument name="portPath" xsi:type="string">loggin/gelf/transport_port</argument>
         </arguments>
     </virtualType>
 
-    <virtualType name="gelfPublisher" type="Gelf\Publisher">
+    <virtualType name="GelfPublisher" type="Gelf\Publisher">
         <arguments>
-            <argument name="transport" xsi:type="object">gelfTransport</argument>
+            <argument name="transport" xsi:type="object">GelfTransport</argument>
         </arguments>
     </virtualType>
 
@@ -25,7 +24,7 @@
         <arguments>
             <argument name="isEnabled" xsi:type="string">loggin/gelf/is_enabled</argument>
             <argument name="levelPath" xsi:type="string">loggin/gelf/level</argument>
-            <argument name="publisher" xsi:type="object">gelfPublisher</argument>
+            <argument name="publisher" xsi:type="object">GelfPublisher</argument>
         </arguments>
     </virtualType>
 
@@ -74,12 +73,7 @@
     <virtualType name="NoopHandler" type="Monolog\Handler\NullHandler"/>
 
     <type name="Magento\Framework\Logger\Monolog">
-        <plugin name="override_set_handlers_method" type="Opengento\Logger\Plugin\MonologPlugin" sortOrder="1"/>
-    </type>
-
-    <type name="Magento\Framework\Logger\Monolog">
         <arguments>
-            <argument name="name" xsi:type="string">main</argument>
             <argument name="handlers" xsi:type="array">
                 <item name="gelf" xsi:type="object">GelfHandler</item>
                 <item name="mail" xsi:type="object">MailHandler</item>
@@ -93,6 +87,6 @@
                 <item name="custom_context" xsi:type="object">Opengento\Logger\Processor\CustomContextProcessor</item>
             </argument>
         </arguments>
+        <plugin name="override_set_handlers_method" type="Opengento\Logger\Plugin\MonologPlugin" sortOrder="1"/>
     </type>
 </config>
-


### PR DESCRIPTION
Using around plugin was resulting in infinite loop (reproduced on Magento 2.4.x)
Fixed by using before plugin without altering the functionality. The initial goal was to update handlers list given to the setHandlers method.