### PR TITLE
chore: drop support for PHP 7 and support at least from 8.1

### DIFF
--- a/Handler/ElasticsearchHandler.php
+++ b/Handler/ElasticsearchHandler.php
@@ -15,18 +15,18 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\NoopHandler;
 use RuntimeException;
 
-readonly class ElasticsearchHandler implements MagentoHandlerInterface
+class ElasticsearchHandler implements MagentoHandlerInterface
 {
     public function __construct(
-        private ScopeConfigInterface $scopeConfig,
-        private string               $isEnabled,
-        private string               $levelPath,
-        private string               $hostPath,
-        private string               $indexPath,
-        private string               $isAuthenticationEnabledPath,
-        private string               $usernamePath,
-        private string               $passwordPath,
-        private string               $ignoreErrorPath,
+        private readonly ScopeConfigInterface $scopeConfig,
+        private readonly string               $isEnabled,
+        private readonly string               $levelPath,
+        private readonly string               $hostPath,
+        private readonly string               $indexPath,
+        private readonly string               $isAuthenticationEnabledPath,
+        private readonly string               $usernamePath,
+        private readonly string               $passwordPath,
+        private readonly string               $ignoreErrorPath,
     )
     {
     }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "Elasticsearch"
     ],
     "require": {
-        "php": "^7.1||^8.0",
+        "php": "^8.1",
         "magento/framework": ">=100.1.0",
         "graylog2/gelf-php": "^1.6.0 || ^2.0.0",
         "elasticsearch/elasticsearch": ">=7.17.2"


### PR DESCRIPTION
I realized I have been a bit too optimistic by using PHP8.2 only features in latest PR (https://github.com/opengento/logger/pull/17)

This commit drops PHP 8.2 featured code and at least support 8.1 which is safer.

Also drop PHP 7 from this version, this is not supported. 