### PR TITLE
Feature/enhance elasticsearch handler

### DIFF
--- a/Client/Elasticsearch/ElasticsearchClientFactory.php
+++ b/Client/Elasticsearch/ElasticsearchClientFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © OpenGento, All rights reserved.
+ * See LICENSE bundled with this library for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Opengento\Logger\Client\Elasticsearch;
+
+use Elastic\Elasticsearch\ClientBuilder as ClientBuilder8;
+use Elasticsearch\ClientBuilder as ClientBuilder7;
+use RuntimeException;
+
+class ElasticsearchClientFactory
+{
+    public static function create(): ClientBuilder7|ClientBuilder8
+    {
+        if (class_exists(ClientBuilder8::class)) {
+            return ClientBuilder8::create();
+        }
+
+        if (class_exists(ClientBuilder7::class)) {
+            return ClientBuilder7::create();
+        }
+
+        throw new RuntimeException('No compatible Elasticsearch ClientBuilder found.');
+    }
+}

--- a/Handler/ElasticsearchHandler.php
+++ b/Handler/ElasticsearchHandler.php
@@ -8,11 +8,11 @@ declare(strict_types=1);
 
 namespace Opengento\Logger\Handler;
 
-use Elasticsearch\ClientBuilder;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Monolog\Handler\ElasticsearchHandler as MonologElasticsearchHandler;
 use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\NoopHandler;
+use Opengento\Logger\Client\Elasticsearch\ElasticsearchClientFactory;
 use RuntimeException;
 
 readonly class ElasticsearchHandler implements MagentoHandlerInterface
@@ -33,9 +33,10 @@ readonly class ElasticsearchHandler implements MagentoHandlerInterface
 
     public function getInstance(): HandlerInterface
     {
-        $client = ClientBuilder::create()->setHosts(
-            [$this->scopeConfig->getValue($this->hostPath)]
-        );
+        $client = ElasticsearchClientFactory::create()
+            ->setHosts(
+                [$this->scopeConfig->getValue($this->hostPath)]
+            );
 
         if ($this->scopeConfig->isSetFlag($this->isAuthenticationEnabledPath)) {
             if (

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.1||^8.0",
         "magento/framework": ">=100.1.0",
         "graylog2/gelf-php": "^1.6.0 || ^2.0.0",
-        "elasticsearch/elasticsearch": ">=7.17.2"
+        "elasticsearch/elasticsearch": "^7.17.2 || ^8.0.0"
     },
     "require-dev": {
         "magento/magento-coding-standard": "^5",

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -51,14 +51,23 @@
                 <field id="host" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label" type="text">
                     <label>Elasticsearch / Opensearch transport host, only one supported</label>
                     <comment>Please specify the port like : https://my-elastic-host:443 otherwise it will fallback to 9200.</comment>
+                    <depends>
+                        <field id="is_enabled">1</field>
+                    </depends>
                 </field>
                 <field id="index" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="15" translate="label" type="text">
                     <label>Elasticsearch / Opensearch index</label>
                     <comment>Index where the logs will be stored</comment>
+                    <depends>
+                        <field id="is_enabled">1</field>
+                    </depends>
                 </field>
                 <field id="is_authentication_enabled" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="20" translate="label" type="select">
                     <label>Authentication enabled</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="is_enabled">1</field>
+                    </depends>
                 </field>
                 <field id="username" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="25" translate="label" type="text">
                     <label>Username</label>
@@ -70,6 +79,7 @@
                 <field id="password" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="30" translate="label" type="obscure">
                     <label>Password</label>
                     <comment>Only used when authentication is enabled</comment>
+                    <backend_model>Magento\Config\Model\Config\Backend\Encrypted</backend_model>
                     <depends>
                         <field id="is_authentication_enabled">1</field>
                     </depends>
@@ -79,11 +89,17 @@
                     <label>Level</label>
                     <source_model>Opengento\Logger\Config\Source\LoggingLevel</source_model>
                     <comment>Messages of this or a higher level will be logged in your log system.</comment>
+                    <depends>
+                        <field id="is_enabled">1</field>
+                    </depends>
                 </field>
                 <field id="ignore_error" showInDefault="1" showInStore="0" showInWebsite="0" sortOrder="40" translate="label" type="select">
                     <label>Ignore errors</label>
                     <comment>By default as true because it can block some functionality if connection is badly configured.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                    <depends>
+                        <field id="is_enabled">1</field>
+                    </depends>
                 </field>
             </group>
             <group id="console" showInDefault="1" showInStore="1" showInWebsite="1" sortOrder="10" translate="label">

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -26,7 +26,7 @@
             </mail>
             <elasticsearch>
                 <is_enabled>0</is_enabled>
-                <level>500</level>
+                <level>100</level>
                 <host/>
                 <index/>
                 <is_authentication_enabled>0</is_authentication_enabled>


### PR DESCRIPTION
Various enhancements after several days of testing in some of our production websites.

- Handle both Elasticsearch v7 and v8 version since newest versions of Magento might need it
- Using a buffer instead of sending one by one to API => for example when we flush the cache we might send over 250 logs which can lead to 250 api calls without the appropriate buffer
- Some enhancements/fixes on configuration