### PR TITLE
fix: adding forgotten backend model to decrypt config

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -31,7 +31,7 @@
                 <index/>
                 <is_authentication_enabled>0</is_authentication_enabled>
                 <username/>
-                <password/>
+                <password backend_model="Magento\Config\Model\Config\Backend\Encrypted"/>
                 <ignore_error>1</ignore_error>
             </elasticsearch>
             <slack>


### PR DESCRIPTION
Sorry, when updating data from previous MR I forgot to include the backend_model as well for the password.

Doing so avoid to decrypt it manually